### PR TITLE
Bug in News Post teaser

### DIFF
--- a/apps/news/models.py
+++ b/apps/news/models.py
@@ -39,7 +39,7 @@ class NewsPost(models.Model):
     @property
     def teaser(self):
         body_without_html_tags = re.sub(re.compile("<.*?>"), "", self.body)
-        return body_without_html_tags[:150]
+        return f'<span>{body_without_html_tags[:150]}</span>'
 
     @property
     def source_divesite(self):

--- a/apps/news/models.py
+++ b/apps/news/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
+import re
 
 from taxonomy.models import DiveSite, Topic
 
@@ -37,7 +38,8 @@ class NewsPost(models.Model):
 
     @property
     def teaser(self):
-        return self.body[:150]
+        body_without_html_tags = re.sub(re.compile("<.*?>"), "", self.body)
+        return body_without_html_tags[:150]
 
     @property
     def source_divesite(self):


### PR DESCRIPTION
Overview: In the teaser method for the NewsPost model, I used regex to remove the html tags from the body before selecting the first 150 characters as the teaser.

Steps to Test:
1. Set the NewsPost with the title "Pandemic had lasting, major implications for employer flexibility, Randstad survey shows" to active.
2. Go to http://127.0.0.1:8000/, scroll to the above article and confirm the html appears correctly.

