### PR TITLE
Make Archive Search Behave Like a Single Page App

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": [
+    "babel-preset-env",
+    "react"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.DS_Store
+node_modules
+static/bundles
+package-lock.json

--- a/apps/news/views.py
+++ b/apps/news/views.py
@@ -42,13 +42,13 @@ def newspost_detail(request, newspost_id):
 
 
 def archive(request):
-    template = loader.get_template('news/archive.html')
-    topics = Topic.objects.all().order_by('display_name')
+    template = loader.get_template('news/spa_archive.html')
+    topics = Topic.objects.all().order_by('display_name').values("pk", "id", "display_name")
     selected_topics, text_search_value = parse_search_terms(request.GET)
     news_archive = NewsPost.search(topics=selected_topics, text_value=text_search_value)
     context = {
         'news_archive': news_archive,
-        'topics': topics,
+        'topics': list(topics),
         'text_search': request.GET.get('text_search'),
         'selected_topics': selected_topics,
         'searched': selected_topics or text_search_value,

--- a/apps/news/views.py
+++ b/apps/news/views.py
@@ -44,16 +44,8 @@ def newspost_detail(request, newspost_id):
 def archive(request):
     template = loader.get_template('news/spa_archive.html')
     topics = Topic.objects.all().order_by('display_name').values("pk", "id", "display_name")
-    selected_topics, text_search_value = parse_search_terms(request.GET)
-    news_archive = NewsPost.search(topics=selected_topics, text_value=text_search_value)
     context = {
-        'news_archive': news_archive,
         'topics': list(topics),
-        'text_search': request.GET.get('text_search'),
-        'selected_topics': selected_topics,
-        'searched': selected_topics or text_search_value,
-        'selected_topics': selected_topics,
-        'text_search_value': text_search_value,
     }
 
     return HttpResponse(template.render(context, request))

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "webpack-cli": "^4.7.2"
   },
   "dependencies": {
+    "css-loader": "^5.2.7",
+    "jquery": "^3.6.0",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "style-loader": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "splashzone-industry-dive",
+  "version": "1.0.0",
+  "description": "Industry Dive's django code exercise for software engineer candidates",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "webpack --config webpack.config.js --progress --colors --mode development",
+    "watch": "webpack --config webpack.config.js --watch --mode development"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sgigli/splashzone-industry-dive.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/sgigli/splashzone-industry-dive/issues"
+  },
+  "homepage": "https://github.com/sgigli/splashzone-industry-dive#readme",
+  "devDependencies": {
+    "babel-core": "^6.26.3",
+    "babel-loader": "^7.1.5",
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-react": "^6.24.1",
+    "webpack": "^4.46.0",
+    "webpack-bundle-tracker": "^1.2.0",
+    "webpack-cli": "^4.7.2"
+  },
+  "dependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ beautifulsoup4==4.8.2
 Django==3.1.6
 pytz==2021.1
 sqlparse==0.4.1
+django-webpack-loader

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
     'news',
     'taxonomy',
     'wavepool',
+    'webpack_loader'
 ]
 
 MIDDLEWARE = [
@@ -47,6 +48,13 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+WEBPACK_LOADER = {
+    'DEFAULT': {
+        'BUNDLE_DIR_NAME': 'bundles/',
+        'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats.json'),
+    }
+}
 
 ROOT_URLCONF = 'project.urls'
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+
+function Welcome(props) {
+  return <h1>Hello, {props.name}</h1>;
+}
+
+const element = <Welcome name="world" />;
+ReactDOM.render(
+  element,
+  document.getElementById('react')
+);

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,12 +1,163 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import $ from 'jquery';
+import "../css/news.css";
 
+class Archive extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      topics: window.props,
+      articles: [],
+      selected_topics: [],
+      search_text: ""
+    };
+  }
 
-function Welcome(props) {
-  return <h1>Hello, {props.name}</h1>;
+  fetchSearchResults() {
+    const selected_topics_params = this.state.selected_topics.map((topic) => {
+      return `topics_${topic.pk}=${topic.id}`
+    }).join("&")
+    const spacer = selected_topics_params ? "&" : ""
+    const text_search_param = `text_search=${this.state.search_text}`
+
+    $.ajax({
+      url: "/api/v1/news/?" + selected_topics_params + spacer + text_search_param,
+      type: "GET",
+      dataType: "json",
+      success: (data) => {
+        this.setState({ articles: data })
+      },
+      error: (error) => {
+        console.log(error)
+      }
+    })
+  }
+
+  onTopicSelection(topic) {
+    const topic_index = this.state.selected_topics.indexOf(topic)
+    let new_selected_topics
+    if (topic_index !== -1){
+      new_selected_topics = this.state.selected_topics.filter((t) => t !== topic)
+    } else {
+      new_selected_topics = this.state.selected_topics.concat(topic)
+    }
+
+    this.setState({ selected_topics: new_selected_topics }, () => {
+      this.fetchSearchResults()
+    })
+  }
+
+  onTextSearch(e) {
+    this.setState({ search_text: e.target.value}, () => {
+      this.fetchSearchResults()
+    })
+  }
+
+  componentDidMount() {
+    this.fetchSearchResults()
+  }
+
+  render() {
+    const topics = this.state.topics.map((topic, index) => {
+      return (
+        <li key={index}>
+          <input
+            type="checkbox"
+            name={"topics_" + topic.pk}
+            id={"id_topics_" + topic.pk}
+            value={topic.id}
+            onChange={() => this.onTopicSelection(topic)}
+          ></input>
+          {topic.display_name}
+        </li>
+      )
+    })
+
+    return (
+      <div>
+        <form id="archive-filter" method="GET">
+          <div className="form-group row">
+            <div className="col-sm-2 col-form-label">
+              <label htmlFor="topics">Filter by topic:</label>
+            </div>
+            <div className="col">
+              <ul className="form form-multiselect">
+                {topics}
+              </ul>
+            </div>
+            <div className="col-sm-1 col-form-label">
+              <label htmlFor="text_search">Text:</label>
+            </div>
+            <div className="col">
+              <input type="text" id="id_text_search" name="text_search" className="form-control" onChange={(e) => this.onTextSearch(e)}/>
+            </div>
+          </div>
+        </form>
+        {<ResultsHeader selected_topics={this.state.selected_topics} search_text={this.state.search_text}/>}
+        <ul className="feed" id="archive">
+          {this.state.articles.map((article, index) => {
+            return <Article article={article} index={index} key={index}/>
+          })}
+        </ul>
+      </div>
+    );
+  }
 }
 
-const element = <Welcome name="world" />;
+function Article({ article, index }) {
+  return (
+    <li data-newspost-id={article.pk} data-feed-placement={index} key={index}>
+      <span className="label label--soft">
+        {article.publish_date}
+      </span>
+        {article.topics.map((topic, index) => {
+          return <div className="label label--tag" key={index}>{topic.display_name}</div>
+        })}
+      <div className="feed-link">
+        <a href={article.url}>{ article.title }</a>
+      </div>
+      <div className="feed-teaser" data-story_id={article.pk}>
+        { article.teaser.replace( /(<([^>]+)>)/ig, '') }
+        <span>...</span>
+      </div>
+    </li>
+  )
+}
+
+function ResultsHeader({ selected_topics, search_text }) {
+  if (selected_topics.length || search_text) {
+    return (
+      <span className="search">
+        <div className="row" id="search-result-header">
+          <h2>Search Results</h2>
+        </div>
+        <div className="row search-description">
+          { search_text && 
+            <div className="col">
+              <b>Search term:</b> {search_text}
+            </div> }
+          { selected_topics && 
+            <div className="col">
+              <b>Topics:</b>
+                { selected_topics.map((topic, index) => {
+                    return <div className="label label--tag" key={index}>{topic.display_name}</div>
+                  }) }
+            </div>
+          }
+        </div>
+      </span>
+    )
+  } else {
+    return (
+      <div className="row">
+        <h2>News Archive</h2>
+      </div>
+    )
+  }
+}
+
+const element = <Archive />;
 ReactDOM.render(
   element,
   document.getElementById('react')

--- a/templates/news/spa_archive.html
+++ b/templates/news/spa_archive.html
@@ -1,0 +1,11 @@
+{% extends 'wavepool/base.html' %}
+{% load render_bundle from webpack_loader %}
+
+{% block page_content %}
+  <div id="react"></div>
+  <script>
+    window.props = {{ topics|safe }}
+    window.react_mount = document.getElementById('react')
+  </script>
+  {% render_bundle 'main' %}
+{% endblock %}

--- a/webpack-stats.json
+++ b/webpack-stats.json
@@ -1,0 +1,1 @@
+{"status":"done","assets":{"main-8e068d32cbd120d7b4dd.js":{"name":"main-8e068d32cbd120d7b4dd.js","path":"/Users/simon/Documents/code/jobs/industry_dive/splashzone-industry-dive/static/bundles/main-8e068d32cbd120d7b4dd.js"}},"chunks":{"main":["main-8e068d32cbd120d7b4dd.js"]}}

--- a/webpack-stats.json
+++ b/webpack-stats.json
@@ -1,1 +1,1 @@
-{"status":"done","assets":{"main-8e068d32cbd120d7b4dd.js":{"name":"main-8e068d32cbd120d7b4dd.js","path":"/Users/simon/Documents/code/jobs/industry_dive/splashzone-industry-dive/static/bundles/main-8e068d32cbd120d7b4dd.js"}},"chunks":{"main":["main-8e068d32cbd120d7b4dd.js"]}}
+{"status":"done","assets":{"main-c5a9410170b84f4f146b.js":{"name":"main-c5a9410170b84f4f146b.js","path":"/Users/simon/Documents/code/jobs/industry_dive/splashzone-industry-dive/static/bundles/main-c5a9410170b84f4f146b.js"}},"chunks":{"main":["main-c5a9410170b84f4f146b.js"]}}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,14 @@ module.exports = {
         test: /\.js$/,
         exclude: /node_modules/,
         use: ['babel-loader'],
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader']
+      },
+      {
+        test: /\.css$/,
+        use: ['css-loader']
       }
     ]
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,31 @@
+var path = require("path");
+var webpack = require('webpack');
+var BundleTracker = require('webpack-bundle-tracker');
+
+module.exports = {
+  context: __dirname,
+
+  entry: './static/js/index',
+
+  output: {
+      path: path.resolve('./static/bundles/'),
+      filename: "[name]-[hash].js",
+  },
+
+  plugins: [
+    new BundleTracker({filename: './webpack-stats.json'}),
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: ['babel-loader'],
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['*', '.js', '.jsx']
+  }
+
+};


### PR DESCRIPTION
Solution Overview: I wanted to go with a React solution because I thought its state management would really help make a clean solution for the SPA archive page. So I first set up React using Webpack and Babel, and then installed all the necessary packages. I then setup the main Archive component to use its state to keep track of the selected topics, search text, and returned articles. Whenever the filters changed, I would fire off a get request to the archive API and refresh the page's results. Lastly I updated the archive view by removing the variables that were needed for server side rendering. 

Steps to Test:
1. Install packages with `npm install`.
2. Run `npm run watch` in the terminal to create the Wepback bundle (alongside your running local server).
3. Go to http://127.0.0.1:8000/news/archive/ and confirm that page responds to any selected topics or search text.